### PR TITLE
PR6 Add analytics

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -30,5 +30,16 @@ module.exports = {
         path: `${__dirname}/src/images/`,
       }
     },
+    {
+      resolve: 'gatsby-plugin-google-gtag',
+      options: {
+        trackingIds: [
+          "AW-11417146217",
+        ],
+        gtagConfig: {
+          anonymize_ip: true,
+        }
+      }
+    },
   ],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "0BSD",
       "dependencies": {
         "gatsby": "^5.13.0",
+        "gatsby-plugin-google-gtag": "^5.13.0",
         "gatsby-plugin-image": "^3.13.0",
         "gatsby-plugin-sharp": "^5.13.0",
         "gatsby-source-filesystem": "^5.13.0",
@@ -8613,6 +8614,23 @@
       },
       "peerDependencies": {
         "@parcel/core": "^2.0.0"
+      }
+    },
+    "node_modules/gatsby-plugin-google-gtag": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-gtag/-/gatsby-plugin-google-gtag-5.13.0.tgz",
+      "integrity": "sha512-UPC/wET8T6ZdNjpQrz43EnRUQ2WjTX5E7HT3kfwshcYSjtGyBo4RxDdY6lnnmG8gQxmsUL86cvzqQt0ojs2xAQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "gatsby": "^5.0.0-next",
+        "react": "^18.0.0 || ^0.0.0",
+        "react-dom": "^18.0.0 || ^0.0.0"
       }
     },
     "node_modules/gatsby-plugin-image": {
@@ -22165,6 +22183,15 @@
         "@parcel/runtime-js": "2.8.3",
         "@parcel/transformer-js": "2.8.3",
         "@parcel/transformer-json": "2.8.3"
+      }
+    },
+    "gatsby-plugin-google-gtag": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-gtag/-/gatsby-plugin-google-gtag-5.13.0.tgz",
+      "integrity": "sha512-UPC/wET8T6ZdNjpQrz43EnRUQ2WjTX5E7HT3kfwshcYSjtGyBo4RxDdY6lnnmG8gQxmsUL86cvzqQt0ojs2xAQ==",
+      "requires": {
+        "@babel/runtime": "^7.20.13",
+        "minimatch": "^3.1.2"
       }
     },
     "gatsby-plugin-image": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "gatsby": "^5.13.0",
+    "gatsby-plugin-google-gtag": "^5.13.0",
     "gatsby-plugin-image": "^3.13.0",
     "gatsby-plugin-sharp": "^5.13.0",
     "gatsby-source-filesystem": "^5.13.0",

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,6 +2,7 @@ import * as React from "react"
 import Layout from '../components/layout'
 import Seo from '../components/seo'
 import { StaticImage } from 'gatsby-plugin-image'
+import { OutboundLink } from "gatsby-plugin-google-gtag"
 
 const IndexPage = () => {
   return (
@@ -22,7 +23,9 @@ const IndexPage = () => {
             live for, and he still has plenty to lose.
           </p>
           <p>Read for free 
-            on <a href="https://www.royalroad.com/fiction/76242/hungry-new-world">Royal Road</a> until January 2024.
+            on <OutboundLink href="https://www.royalroad.com/fiction/76242/hungry-new-world">
+              Royal Road
+            </OutboundLink> until January 2024.
           </p>
         </div>
       </div>
@@ -67,11 +70,11 @@ const IndexPage = () => {
           change, to prevent the world's forgotten history from repeating. Everyone's lives 
           depends on it.
         </p>
-        <p>Read at <a href="https://www.amazon.com/dp/B0BSPB38P8"
-          alt="Tenobre books at Amazon">Amazon</a> or anywhere e-books and paperbacks are
+        <p>Read at <OutboundLink href="https://www.amazon.com/dp/B0BSPB38P8"
+          alt="Tenobre books at Amazon">Amazon</OutboundLink> or anywhere e-books and paperbacks are
           sold.
         </p>
-        <p><em>Volume four is scheduled for Spring 2024.</em></p>
+        <p><em>Volume four is scheduled for release in Winter 2024.</em></p>
 
       </div>
 


### PR DESCRIPTION
Add gtag analytics, via gatsby-plugin-google-gtag .

As a side benefit, we also get click-away tracking when we use the OutboundLink component.